### PR TITLE
Help queue multithread tests

### DIFF
--- a/src/help_queue.rs
+++ b/src/help_queue.rs
@@ -458,43 +458,6 @@ mod tests {
     }
 
     #[test]
-    fn two_threads() {
-        let queue = Arc::new(WaitFreeHelpQueue::<_, 2>::new());
-        let mut handles = vec![];
-
-        for id in 0..2 {
-            let queue = queue.clone();
-            handles.push(thread::spawn(move || {
-                let guard = &epoch::pin();
-
-                &queue.enqueue(id, 1, guard);
-
-                drop(guard);
-                let guard = &epoch::pin();
-
-                let elem = &queue.peek(guard);
-                assert_eq!(*elem, Some(1));
-
-                drop(guard);
-                let guard = &epoch::pin();
-
-                let res = &queue.try_remove_front(1, guard);
-                assert!(res.is_ok());
-
-                drop(guard);
-                let guard = &epoch::pin();
-
-                let res = &queue.try_remove_front(1, guard);
-                assert!(res.is_err())
-            }));
-        }
-
-        for handle in handles {
-            handle.join().unwrap();
-        }
-    }
-
-    #[test]
     fn concurrent_enqueue() {
         let queue = Arc::new(WaitFreeHelpQueue::<_, 2>::new());
         let mut handles = vec![];

--- a/src/help_queue.rs
+++ b/src/help_queue.rs
@@ -328,7 +328,6 @@ where
     }
 }
 
-// A wait-free queue.
 unsafe impl<T, const N: usize> Sync for WaitFreeHelpQueue<T, N> {}
 unsafe impl<T, const N: usize> Send for WaitFreeHelpQueue<T, N> {}
 

--- a/src/help_queue.rs
+++ b/src/help_queue.rs
@@ -338,7 +338,65 @@ mod tests {
     use std::thread;
 
     #[test]
-    fn single_threaded() {
+    fn new() {
+        let _queue = WaitFreeHelpQueue::<i32, 1>::new();
+    }
+
+    #[test]
+    fn enqueue() {
+        const ID: usize = 0usize;
+        let queue = WaitFreeHelpQueue::<_, 1>::new();
+
+        let guard = &epoch::pin();
+
+        queue.enqueue(ID, 1, guard);
+        drop(guard);
+
+        let guard = &epoch::pin();
+
+        let elem = queue.peek(guard);
+        assert_eq!(elem, Some(1));
+    }
+
+    #[test]
+    fn peek_empty() {
+        let queue = WaitFreeHelpQueue::<i32, 1>::new();
+
+        let guard = &epoch::pin();
+        let elem = queue.peek(guard);
+        assert!(elem.is_none());
+    }
+
+    #[test]
+    fn remove_empty() {
+        let queue = WaitFreeHelpQueue::<i32, 1>::new();
+
+        let guard = &epoch::pin();
+        let res = queue.try_remove_front(1, guard);
+        assert!(res.is_err());
+    }
+
+    #[test]
+    fn remove_wrong_front() {
+        const ID: usize = 0usize;
+        let queue = WaitFreeHelpQueue::<_, 1>::new();
+
+        let guard = &epoch::pin();
+
+        queue.enqueue(ID, 1, guard);
+        drop(guard);
+
+        let guard = &epoch::pin();
+
+        let elem = queue.peek(guard);
+        assert_eq!(elem, Some(1));
+
+        let res = queue.try_remove_front(2, guard);
+        assert!(res.is_err());
+    }
+
+    #[test]
+    fn insert_get_remove() {
         const ID: usize = 0usize;
         let queue = WaitFreeHelpQueue::<_, 1>::new();
 
@@ -359,14 +417,10 @@ mod tests {
         assert!(res.is_ok());
 
         drop(guard);
-        let guard = &epoch::pin();
-
-        let res = queue.try_remove_front(1, guard);
-        assert!(res.is_err());
     }
 
     #[test]
-    fn single_threaded_2() {
+    fn insert_two_remove_both() {
         const ID: usize = 0usize;
         let queue = WaitFreeHelpQueue::<_, 1>::new();
 
@@ -383,13 +437,6 @@ mod tests {
 
         let elem = queue.peek(guard);
         assert_eq!(elem, Some(1));
-
-        drop(guard);
-        let guard = &epoch::pin();
-
-        // Fail to enqueue element not on top
-        let res = queue.try_remove_front(2, guard);
-        assert!(res.is_err());
 
         drop(guard);
         let guard = &epoch::pin();
@@ -448,64 +495,17 @@ mod tests {
     }
 
     #[test]
-    #[ignore]
-    fn many_threads() {
-        let queue = Arc::new(WaitFreeHelpQueue::<_, 1000>::new());
+    fn concurrent_enqueue() {
+        let queue = Arc::new(WaitFreeHelpQueue::<_, 2>::new());
         let mut handles = vec![];
 
-        for id in 0..1000 {
+        for id in 0..2 {
             let queue = queue.clone();
             handles.push(thread::spawn(move || {
-                let guard = &epoch::pin();
-
-                &queue.enqueue(id, 1, guard);
-
-                drop(guard);
-                let guard = &epoch::pin();
-
-                let elem = &queue.peek(guard);
-                assert_eq!(*elem, Some(1));
-
-                drop(guard);
-                let guard = &epoch::pin();
-
-                let res = &queue.try_remove_front(1, guard);
-                assert!(res.is_ok());
-
-                drop(guard);
-            }));
-        }
-
-        for handle in handles {
-            handle.join().unwrap();
-        }
-    }
-
-    #[test]
-    #[ignore]
-    fn many_threads_many_actions() {
-        let queue = Arc::new(WaitFreeHelpQueue::<_, 1000>::new());
-        let mut handles = vec![];
-
-        for id in 0..1000 {
-            let queue = queue.clone();
-            handles.push(thread::spawn(move || {
-                for run in 0..100 {
+                for _ in 0..10000 {
                     let guard = &epoch::pin();
 
-                    &queue.enqueue(id, run, guard);
-
-                    drop(guard);
-                    let guard = &epoch::pin();
-
-                    let elem = &queue.peek(guard);
-                    assert!(elem.is_some());
-
-                    drop(guard);
-                    let guard = &epoch::pin();
-
-                    let res = &queue.try_remove_front(run, guard);
-                    assert!(res.is_ok());
+                    &queue.enqueue(id, id, guard);
 
                     drop(guard);
                 }
@@ -515,5 +515,52 @@ mod tests {
         for handle in handles {
             handle.join().unwrap();
         }
+
+        for _ in 0..20000 {
+            let guard = &epoch::pin();
+
+            let elem = &queue.peek(guard);
+            assert!(*elem == Some(0) || *elem == Some(1));
+
+            drop(guard);
+        }
+    }
+
+    #[test]
+    fn concurrent_remove() {
+        let queue = Arc::new(WaitFreeHelpQueue::<_, 2>::new());
+
+        for val in 0..10000 {
+            let guard = &epoch::pin();
+
+            &queue.enqueue(0, val, guard);
+
+            drop(guard);
+        }
+
+        let mut handles = vec![];
+        for _ in 0..2 {
+            let queue = queue.clone();
+            handles.push(thread::spawn(move || {
+                let mut counter = 0;
+                for val in 0..10000 {
+                    let guard = &epoch::pin();
+                    if let Ok(()) = &queue.try_remove_front(val, guard) {
+                        counter += 1;
+                    }
+
+                    drop(guard);
+                }
+                println!("counter: {}", counter);
+            }));
+        }
+
+        for handle in handles {
+            handle.join().unwrap();
+        }
+
+        let guard = &epoch::pin();
+        let elem = &queue.peek(guard);
+        assert!(elem.is_none());
     }
 }


### PR DESCRIPTION
Modify the current basic tests, add some more tests and specifically add tests checking the concurrency properties of the help queue.